### PR TITLE
fix(security): ne plus embarquer .env dans l'image (V2) + envoi clé API (V1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Secrets — ne JAMAIS embarquer dans l'image (injectés au runtime via env_file)
+.env
+.env.*
+!.env.example
+
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+.pytest_cache/
+
+# Divers
+*.log
+.DS_Store
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ COPY data ./data
 # Installer les dépendances
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copier le fichier .env
-COPY .env .
+# NB : on ne copie PAS .env dans l'image (cela graverait les secrets dans une
+# couche de l'image). Les variables sont injectées au runtime par
+# docker-compose via `env_file: .env`.
 
 EXPOSE 8080
 

--- a/utils/web_server.py
+++ b/utils/web_server.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import os
 import time
 import uuid
 
@@ -27,6 +28,9 @@ from utils.logger import logger
 
 ZONE01_DOMAIN = "zone01normandie.org"
 ZONE01_API_URL = "https://api-zone01-rouen.deno.dev/api/v1"
+# Clé partagée pour autoriser les mutations de l'API Deno (doit être identique
+# à API_ADMIN_KEY côté API). Injectée au runtime via l'environnement.
+API_ADMIN_KEY = os.getenv("API_ADMIN_KEY", "")
 
 TOKEN_TTL = 600  # secondes (10 minutes)
 
@@ -331,6 +335,7 @@ async def _handle_post(request: web.Request, bot: discord.Client) -> web.Respons
             async with session.put(
                 f"{ZONE01_API_URL}/discord-users",
                 json={"login": login, "discord_id": discord_id},
+                headers={"X-Api-Key": API_ADMIN_KEY},
                 timeout=aiohttp.ClientTimeout(total=10),
             ) as api_resp:
                 if not api_resp.ok:


### PR DESCRIPTION
## V2 — Secrets gravés dans l'image Docker
`COPY .env .` gravait le **token Discord** (et autres secrets) dans une couche de l'image.
- Suppression du `COPY .env` (les variables sont injectées au runtime via `docker-compose env_file`).
- Ajout d'un **`.dockerignore`** excluant `.env`.

## V1 (côté client)
- `PUT /discord-users` envoie maintenant l'en-tête **`X-Api-Key`** (`API_ADMIN_KEY`) requis par l'API.

## 🚨 ACTION MANUELLE REQUISE
Le token Discord est **déjà fuité dans l'historique git** (commit `34ad275`). Le correctif empêche les futures images de le contenir, **mais il faut FAIRE TOURNER le token** (et les autres secrets du `.env`) pour neutraliser la fuite.

## ⚠️ Déploiement
Définir `API_ADMIN_KEY` (même valeur que l'API Deno) dans l'env du bot, et déployer avec la PR de l'API.

## Vérif
`python -m py_compile utils/web_server.py` : OK.

> Note : ce repo (origin = makcimerrr) est un fork ; le VPS tire depuis `Zone01Rouen/bot-discord-zone01` — penser à synchroniser après merge.
🤖 Generated with [Claude Code](https://claude.com/claude-code)